### PR TITLE
Update httpclient

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,12 +10,21 @@ GEM
     addressable (2.3.8)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     httpclient (2.6.0.1)
     json (1.8.3)
+    method_source (0.8.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-doc (0.8.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -36,6 +45,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -48,6 +58,8 @@ DEPENDENCIES
   bundler (~> 1.10)
   codeclimate-test-reporter
   dpn-client!
+  pry
+  pry-doc
   rake (~> 10.0)
   rspec
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dpn-client (2.0.0)
+    dpn-client (2.0.1)
       httpclient (~> 2.8.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     dpn-client (2.0.0)
-      httpclient (~> 2.6.0.1)
+      httpclient (~> 2.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -15,7 +15,7 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    httpclient (2.6.0.1)
+    httpclient (2.8.2.4)
     json (1.8.3)
     method_source (0.8.2)
     pry (0.10.3)

--- a/dpn-client.gemspec
+++ b/dpn-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "httpclient", "~> 2.6.0.1"
+  spec.add_runtime_dependency "httpclient", "~> 2.8.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "pry"

--- a/dpn-client.gemspec
+++ b/dpn-client.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "httpclient", "~> 2.6.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-doc"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "yard"

--- a/lib/dpn/client/agent/configuration.rb
+++ b/lib/dpn/client/agent/configuration.rb
@@ -26,6 +26,13 @@ module DPN
                       :per_page, :user_agent
         attr_writer :logger
 
+        def api_ver
+          @api_ver ||= "api-v#{DPN::Client.api_version}"
+        end
+
+        def base_url
+          @api_root
+        end
 
         # Apply the options hash to the configuration
         def configure(options_hash = {})
@@ -50,9 +57,6 @@ module DPN
         end
         alias_method  :setup, :reset
 
-        def base_url
-          File.join(@api_root, "api-v#{DPN::Client.api_version}")
-        end
 
         def logger
           @logger ||= NullLogger.new

--- a/lib/dpn/client/agent/connection.rb
+++ b/lib/dpn/client/agent/connection.rb
@@ -153,7 +153,7 @@ module DPN
         def parse_url(raw_url)
           url, query = raw_url.split("?", 2)
           query = if query
-                    URI::decode_www_form(query).to_h
+                    URI.decode_www_form(query).to_h
                   else
                     {}
                   end

--- a/lib/dpn/client/agent/connection.rb
+++ b/lib/dpn/client/agent/connection.rb
@@ -119,40 +119,6 @@ module DPN
 
         protected
 
-        def request(method, url, query, body, &block)
-          url, extra_query = parse_url(url)
-          query ||= {}
-          options = {
-              query: stringify_nested_arrays!(query.merge(extra_query)),
-              body: body.to_json,
-              follow_redirect: true
-          }
-
-          logger.info("Sending #{method.upcase}: #{File.join(base_url, fix_url(url))} #{options} ")
-          raw_response = connection.request method, fix_url(url), options
-          logger.debug("Received #{raw_response.inspect}")
-          response = DPN::Client::Response.new(raw_response)
-          logger.info("Received #{response.status}")
-          if block_given?
-            yield response
-          end
-
-          return response
-        end
-
-
-        def parse_url(raw_url)
-          url, query = raw_url.split("?", 2)
-          url = File.join url, ""
-          if query
-            query = URI::decode_www_form(query).to_h
-          else
-            query = {}
-          end
-          return url, query
-        end
-
-
         def connection
           @connection ||= ::HTTPClient.new({
               agent_name: user_agent,
@@ -165,11 +131,39 @@ module DPN
           })
         end
 
-
-        def fix_url(url)
-          File.join url, "/"
+        def request(method, url, query, body, &block)
+          url, extra_query = parse_url(url)
+          query ||= {}
+          options = {
+              query: stringify_nested_arrays!(query.merge(extra_query)),
+              body: body.to_json,
+              follow_redirect: true
+          }
+          logger.info("Sending #{method.upcase}: #{File.join(base_url, url)} #{options} ")
+          raw_response = connection.request method, url, options
+          logger.debug("Received #{raw_response.inspect}")
+          response = DPN::Client::Response.new(raw_response)
+          logger.info("Received #{response.status}")
+          if block_given?
+            yield response
+          end
+          response
         end
 
+        def parse_url(raw_url)
+          url, query = raw_url.split("?", 2)
+          query = if query
+                    URI::decode_www_form(query).to_h
+                  else
+                    {}
+                  end
+          return fix_url(url), query
+        end
+
+        def fix_url(url)
+          url = File.join(api_ver, url) unless url.include?(api_ver)
+          File.join "/", url, "/"
+        end
 
         # Convert array values to csv
         # Only goes one level deep.

--- a/lib/dpn/client/version.rb
+++ b/lib/dpn/client/version.rb
@@ -5,6 +5,6 @@
 
 module DPN
   module Client
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/dpn/client/agent/connection_spec.rb
+++ b/spec/dpn/client/agent/connection_spec.rb
@@ -9,7 +9,7 @@ shared_examples "basic http" do |operation, *args|
   let(:body) {  {tag: "content" } }
   before(:each) do
     @request = stub_request(operation, stub_url)
-                   .to_return(body: body.to_json, status: 200, headers: {content_type: "application/json"})
+                   .to_return(body: body.to_json, status: 200, headers: headers)
   end
 
   it "requests a url" do
@@ -68,6 +68,8 @@ end
 
 
 describe DPN::Client::Agent::Connection do
+  let!(:headers) { {content_type: "application/json"} }
+
   let(:connection) { DPN::Client::Agent.new(api_root: test_api_root, auth_token: "some_auth_token") }
   let(:url) { 'bag' }
   let(:stub_url) { dpn_url(url) }
@@ -86,7 +88,7 @@ describe DPN::Client::Agent::Connection do
     it "handles query parameters" do
       real_query = "a=1,2,3&b=foo"
       stub = stub_request(:get, stub_url).with(query: real_query)
-        .to_return(body: "{}", status: 200, headers: {content_type: "application/json"})
+        .to_return(body: "{}", status: 200, headers: headers)
 
       connection.get(url, { a: [1,2,3], b: "foo" } )
 
@@ -108,7 +110,6 @@ describe DPN::Client::Agent::Connection do
 
   describe "#paginate" do
 
-
     it "requires a block" do
       expect {
         connection.paginate(url, {}, 25)
@@ -117,10 +118,17 @@ describe DPN::Client::Agent::Connection do
 
     [{}, { a: "foo", b: "bar" }].each do |query_params| # WebMock breaks if we supply an array here.
       context "with query==#{query_params}" do          # We don't bother because we tested it in GET
-        context "with one successful page" do
-          let!(:query) { query_params }
-          let!(:page_size) { 25 }
-          let!(:bodies) {
+        let(:query) { query_params.merge(page: 1, page_size: page_size) }
+        let(:page_size) { 25 } # default, overriden in some contexts
+
+        def stub(query, body, status)
+          stub_request(:get, stub_url)
+            .with(query: query)
+            .to_return(body: body, status: status, headers: headers)
+        end
+
+        context "when a query matches one result" do
+          let(:bodies) {
             [] << {
               count: 1,
               next: nil,
@@ -130,111 +138,54 @@ describe DPN::Client::Agent::Connection do
               ]
             }.to_json
           }
-          let!(:headers) { {content_type: "application/json"} }
-          let!(:stubs) {
-            [] << stub_request(:get, stub_url).with(query: query.merge({page: 1, page_size: 25}))
-                    .to_return(body: bodies[0], status: 200, headers: headers)
-          }
 
-          it_behaves_like "pagination"
+          context "success" do
+            let!(:stubs) { [stub(query, bodies[0], 200)] }
+            it_behaves_like "pagination"
+          end
 
-        end # with one page
+          context "failure" do
+            let!(:stubs) { [stub(query, bodies[0], 400)] }
+            it_behaves_like "pagination"
+          end
+        end
 
-        context "with many successful pages" do
-          let!(:query) { query_params }
-          let!(:page_size) { 1 }
-          let!(:bodies) {[
-            {count: 3, next: "next", previous: nil, results: [{ a: "a1" }]}.to_json,
-            {count: 3, next: "next", previous: "prev", results: [{ b: "b2" }]}.to_json,
-            {count: 3, next: nil, previous: "prev", results: [{ c: "c3" }]}.to_json
-          ]}
-          let!(:headers) { {content_type: "application/json"} }
-          let!(:stubs) {
+        context "when a query matches many results" do
+          let(:bodies) {
             [
-              stub_request(:get, stub_url).with(query: query.merge({page: 1, page_size: 1}))
-                .to_return(body: bodies[0], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 2, page_size: 1}))
-                .to_return(body: bodies[1], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 3, page_size: 1}))
-                .to_return(body: bodies[2], status: 200, headers: headers)
+              { count: 3, next: "next", previous: nil,    results: [{ a: "a1" }] }.to_json,
+              { count: 3, next: "next", previous: "prev", results: [{ b: "b2" }] }.to_json,
+              { count: 3, next: nil,    previous: "prev", results: [{ c: "c3" }] }.to_json
             ]
           }
 
-          it_behaves_like "pagination"
-        end
-
-        context "with one failed page" do
-          let!(:query) { query_params }
-          let!(:page_size) { 25 }
-          let!(:bodies) {
-            [] << {
-              count: 1,
-              next: nil,
-              previous: nil,
-              results: [
-                { foo: "bar" }
-              ]
-            }.to_json
-          }
-          let!(:headers) { {content_type: "application/json"} }
-          let!(:stubs) {
-            [] << stub_request(:get, stub_url).with(query: query.merge({page: 1, page_size: 25}))
-                    .to_return(body: bodies[0], status: 400, headers: headers)
-          }
-
-          it_behaves_like "pagination"
-        end
-
-        context "with two successful then one failed pages" do
-          let!(:query) { query_params }
-          let!(:page_size) { 1 }
-          let!(:bodies) {[
-            {count: 3, next: "next", previous: nil, results: [{ a: "a1" }]}.to_json,
-            {count: 3, next: "next", previous: "prev", results: [{ b: "b2" }]}.to_json,
-            {count: 3, next: nil, previous: "prev", results: [{ c: "c3" }]}.to_json
-          ]}
-          let!(:headers) { {content_type: "application/json"} }
-          let!(:stubs) {
+          def create_stubs(status)
             [
-              stub_request(:get, stub_url).with(query: query.merge({page: 1, page_size: 1}))
-                .to_return(body: bodies[0], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 2, page_size: 1}))
-                .to_return(body: bodies[1], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 3, page_size: 1}))
-                .to_return(body: bodies[2], status: 400, headers: headers)
+              stub(query,                              bodies[0], status[0]),
+              stub(query.merge(page: 2, page_size: 1), bodies[1], status[1]),
+              stub(query.merge(page: 3, page_size: 1), bodies[2], status[2])
             ]
-          }
+          end
 
-          it_behaves_like "pagination"
+          context "with successful pages" do
+            let(:page_size) { 1 }
+            let!(:stubs) { create_stubs([200, 200, 200]) }
+            it_behaves_like "pagination"
+          end
+
+          context "with successful pages followed by a failed page" do
+            let(:page_size) { 1 }
+            let!(:stubs) { create_stubs([200, 200, 400]) }
+            it_behaves_like "pagination"
+          end
+
+          context "with a response that changes the page size" do
+            # page_size == 25 (a default), then it changes to 1
+            let!(:stubs) { create_stubs([200, 200, 400]) }
+            it_behaves_like "pagination"
+          end
         end
-
-        context "with a response that changes the page size" do
-          let!(:query) { query_params }
-          let!(:page_size) { 25 } # primary change
-          let!(:bodies) {[
-            {count: 3, next: "next", previous: nil, results: [{ a: "a1" }]}.to_json,
-            {count: 3, next: "next", previous: "prev", results: [{ b: "b2" }]}.to_json,
-            {count: 3, next: nil, previous: "prev", results: [{ c: "c3" }]}.to_json
-          ]}
-          let!(:headers) { {content_type: "application/json"} }
-          let!(:stubs) {
-            [
-              stub_request(:get, stub_url).with(query: query.merge({page: 1, page_size: 25}))
-                .to_return(body: bodies[0], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 2, page_size: 1}))
-                .to_return(body: bodies[1], status: 200, headers: headers),
-              stub_request(:get, stub_url).with(query: query.merge({page: 3, page_size: 1}))
-                .to_return(body: bodies[2], status: 400, headers: headers)
-            ]
-          }
-
-          it_behaves_like "pagination"
-        end
-
       end
     end
-
-
   end
-
 end

--- a/spec/dpn/client/agent/restore_spec.rb
+++ b/spec/dpn/client/agent/restore_spec.rb
@@ -10,7 +10,7 @@ describe DPN::Client::Agent::Restore do
   let(:agent) { DPN::Client::Agent.new(api_root: test_api_root, auth_token: "some_auth_token") }
   headers =  {content_type: "application/json"}
   restore_id = "somerestoreid"
-  
+
 
   describe "#restores" do
     page_size = 1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ def test_api_root
 end
 
 def test_api_ver
-  @test_api_ver ||= "api-v#{DPN::Client::api_version}"
+  @test_api_ver ||= "api-v#{DPN::Client.api_version}"
 end
 
 def test_api_url

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ CodeClimate::TestReporter.start
 
 require 'bundler/setup'
 Bundler.require
+require 'pry'
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'dpn/client'
@@ -18,19 +19,32 @@ WebMock.disable_net_connect!(allow_localhost: false)
 WebMock.disable!
 
 def test_api_root
-  "https://test.client.dpn.org"
+  @test_api_root ||= "https://test.client.dpn.org"
 end
 
-def dpn_url(url)
-  url, query = url.split("?")
-  api_string = "api-v#{DPN::Client::api_version}"
-  if query
-    File.join test_api_root, api_string, url, "/?#{query}"
+def test_api_ver
+  @test_api_ver ||= "api-v#{DPN::Client::api_version}"
+end
+
+def test_api_url
+  @test_api_url ||= File.join test_api_root, test_api_ver
+end
+
+def dpn_path(url)
+  url.sub!(test_api_root,'')
+  url.sub!(test_api_ver, '')
+  if url.include?('?')
+    url, query = url.split('?')
+    File.join url.to_s, "?#{query}"
   else
-    File.join test_api_root, api_string, url, "/"
+    File.join url, '/'
   end
 end
 
+def dpn_url(url)
+  path = dpn_path(url)
+  File.join test_api_url, path
+end
 
 require "helpers/single_endpoint"
 require "helpers/paged_endpoint"


### PR DESCRIPTION
Some deprecation warnings that fill logs are resolved in v2.7.1, see
https://github.com/nahi/httpclient/issues/292

This PR updates HTTPClient to the latest version.  There are some changes in how it handles the `base_url` -- it seems to strip all the path from it.  So it can't be initialized with a
`base_url = 'http://example.com/api-v2'` because it will remove the `/api-v2`.  To work around this, the connection now ensures that the path has `api-v2` (or v-something) at the beginning of the path.  This surfaced some inconsistencies in how the path was defined and stubbed in the specs, so this PR includes some tweaks to how this is done in the specs.

This version of the client has not yet been tested directly against the dpn-server API.  Given all the stubs in the specs, it cannot be tested directly against a running dpn-server app.  It can be tested when used in the dpn-sync project, which uses VCR to record interactions with a running dpn-server app.  This should be done before accepting this PR.